### PR TITLE
Tellduslive

### DIFF
--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -56,7 +56,7 @@ CONFIG_SCHEMA = vol.Schema({
 ATTR_LAST_UPDATED = 'time_last_updated'
 
 
-def save_config(filename, config=None):
+def save_config(filename, config):
     """Save configurator configuration."""
     try:
         with open(filename, 'w') as fdesc:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -180,22 +180,24 @@ def setup(hass, config, session=None):
 
     conf = load_config()
 
+    LEGACY_CONF_KEYS = {CONF_PUBLIC_KEY,
+                        CONF_PRIVATE_KEY,
+                        CONF_TOKEN,
+                        CONF_TOKEN_SECRET}
     if session:
         _LOGGER.debug('Configured by configurator')
-    elif all(key in config.get(DOMAIN, {}) for key in [
-            # Can we get voiuptous to do this?
-            # i.e. have a group of configuration items that
-            # are optional, but if any is present, all have to be
-            CONF_PUBLIC_KEY,
-            CONF_PRIVATE_KEY,
-            CONF_TOKEN,
-            CONF_TOKEN_SECRET]):
-        # Backwards compatible configuration with developer keys
+    elif all(key in config.get(DOMAIN, {}) for key in LEGACY_CONF_KEYS):
+        # Can we get voiuptous to do this?
+        # i.e. have a group of configuration items that
+        # are optional, but if any is present, all have to be.
         _LOGGER.warning('Old configuration format detected. '
                         'Please consider removing developer keys '
                         'from configuration and instead'
                         'authenticate via user interface.')
-        session = LiveSession(application=PROJECT_NAME, **config[DOMAIN])
+        session = LiveSession(application=PROJECT_NAME,
+                              **{key: val
+                                 for key, val in config[DOMAIN].items()
+                                 if key in LEGACY_CONF_KEYS})
     elif CONF_HOST in conf:
         _LOGGER.debug('Using Local API pre-configured by configurator')
         session = LocalAPISession(**conf[CONF_HOST])

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -139,7 +139,7 @@ def setup(hass, config, local=None, oauth=None):
         """Run when a Tellstick is discovered."""
         if DOMAIN in hass.data:
             return  # Tellstick already configured
-        host, device = info[0], info[1]
+        host, device = info
         if not any(x in device for x in LOCAL_API_DEVICES):
             hass.async_add_job(request_configuration, hass, config)
             return

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -59,7 +59,7 @@ CONFIG_SCHEMA = vol.Schema({
 ATTR_LAST_UPDATED = 'time_last_updated'
 
 
-def setup(hass, config, local=None, oauth=None):
+def setup(hass, config, session):
     """Set up the Telldus Live component."""
 
     config_filename = hass.config.path(TELLLDUS_CONFIG_FILE)
@@ -113,7 +113,7 @@ def setup(hass, config, local=None, oauth=None):
         def configuration_callback(callback_data):
             """Handle the submitted configuration."""
             session.authorize()
-            res = setup(hass, config, local={CONF_HOST: host, CONF_TOKEN: access_token})
+            res = setup(hass, config, session)
             if not res:
                 hass.async_add_job(configurator.notify_errors, instance,
                                    "Unable to connect.")

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -37,7 +37,7 @@ CONF_UPDATE_INTERVAL = 'update_interval'
 PUBLIC_KEY = 'THUPUNECH5YEQA3RE6UYUPRUZ2DUGUGA'
 NOT_SO_PRIVATE_KEY = 'PHES7U2RADREWAFEBUSTUBAWRASWUTUS'
 
-LOCAL_API_DEVICES = ['TellstickZnet', 'TellstickNetV2']
+SUPPORTS_LOCAL_API = ['TellstickZnet', 'TellstickNetV2']
 
 MIN_UPDATE_INTERVAL = timedelta(seconds=5)
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
@@ -161,7 +161,9 @@ def setup(hass, config, session=None):
 
         host, device = info
 
-        if not any(x in device for x in LOCAL_API_DEVICES):
+        supports_local_api = any(dev in device
+                                 for dev in SUPPORTS_LOCAL_API)
+        if not supports_local_api:
             # Configure the cloud service
             hass.async_add_job(request_configuration)
             return

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -28,6 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 TELLLDUS_CONFIG_FILE = 'tellduslive.conf'
 KEY_CONFIG = 'tellduslive_config'
+
 CONF_PUBLIC_KEY = 'public_key'
 CONF_PRIVATE_KEY = 'private_key'
 CONF_TOKEN = 'token'

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -123,7 +123,6 @@ def setup(hass, config, session):
             @asyncio.coroutine
             def success():
                 """Set up was successful."""
-                # Save config
                 if not save_config(
                         {host or DOMAIN: {
                             CONF_TOKEN: access_token,
@@ -147,7 +146,7 @@ def setup(hass, config, session):
     def tellstick_discovered(service, info):
         """Run when a Tellstick is discovered."""
         if DOMAIN in hass.data:
-            return  # Tellstick already configured
+            return  # Already configured
         host, device = info
         if not any(x in device for x in LOCAL_API_DEVICES):
             hass.async_add_job(request_configuration)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -161,6 +161,8 @@ def setup(hass, config, session):
             file_host, _ = file_config.popitem()
             if file_host == host:
                 return
+
+        # Offer configuration of both live and local API
         hass.async_add_job(request_configuration)
         hass.async_add_job(request_configuration, host)
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -183,7 +183,7 @@ def setup(hass, config, client=None):
     if client:
         _LOGGER.debug('Configured by configurator')
     elif all(key in config.get(DOMAIN, {}) for key in legacy_conf_keys):
-        # Can we get voiuptous to do this?
+        # Can we get voiuptous to do this for us?
         # i.e. have a group of configuration items that
         # are optional, but if any is present, all have to be.
         _LOGGER.warning('Old configuration format detected. '

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -124,11 +124,10 @@ def setup(hass, config, client=None):
             @asyncio.coroutine
             def success():
                 """Set up was successful."""
-                res = save_config(config_filename,
-                    {host: {CONF_TOKEN: client.access_token}} if host else
-                    {DOMAIN: {CONF_TOKEN: client.access_token,
-                              CONF_TOKEN_SECRET: client.access_token_secret}})
-                if not res:
+                conf.update({host: {CONF_TOKEN: client.access_token}} if host else
+                            {DOMAIN: {CONF_TOKEN: client.access_token,
+                                      CONF_TOKEN_SECRET: client.access_token_secret}})
+                if not save_config(config_filename, conf):
                     _LOGGER.warning('Failed to save configuration file %s',
                                     config_filename)
                 hass.async_add_job(configurator.request_done, instance)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 
 from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, DEVICE_DEFAULT_NAME)
+    ATTR_BATTERY_LEVEL, DEVICE_DEFAULT_NAME, PROJECT_NAME)
 from homeassistant.helpers import discovery
 from homeassistant.components.discovery import SERVICE_TELLDUSLIVE
 import homeassistant.helpers.config_validation as cv
@@ -96,7 +96,7 @@ def setup(hass, config, local=None, oauth=None):
             'cloud service'))
 
         from tellduslive import Client
-        auth_url, request_token = Client.get_authorize_url(host, app='HA')
+        auth_url, request_token = Client.get_authorize_url(host, app=PROJECT_NAME)
         if not auth_url:
             return
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -111,13 +111,14 @@ def request_configuration(hass, config, host=None):
 def setup(hass, config, local=None, oauth=None):
     """Set up the Telldus Live component."""
 
+    config_filename = hass.config.path(TELLLDUS_CONFIG_FILE)
+
     def config_from_file(config=None):
         """Small configuration file management function (from media_player/plex.py)."""
-        filename = hass.config.path(TELLLDUS_CONFIG_FILE)
         if config:
             # We're writing configuration
             try:
-                with open(filename, 'w') as fdesc:
+                with open(config_filename, 'w') as fdesc:
                     fdesc.write(json.dumps(config))
             except IOError as error:
                 _LOGGER.error("Saving config file failed: %s", error)
@@ -125,9 +126,9 @@ def setup(hass, config, local=None, oauth=None):
             return True
         else:
             # We're reading config
-            if os.path.isfile(filename):
+            if os.path.isfile(config_filename):
                 try:
-                    with open(filename, 'r') as fdesc:
+                    with open(config_filename, 'r') as fdesc:
                         return json.loads(fdesc.read())
                 except (ValueError, IOError) as error:
                     _LOGGER.error("Reading config file failed: %s", error)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -161,7 +161,7 @@ def setup(hass, config, client=None):
             _LOGGER.debug('Tellstick already configured')
             return
 
-        host, device = info
+        host, device = info[:2]
 
         if not supports_local_api(device):
             _LOGGER.debug('Tellstick does not support local API')

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -187,7 +187,7 @@ def setup(hass, config, client=None):
                         CONF_TOKEN,
                         CONF_TOKEN_SECRET}
     if client:
-        _LOGGER.debug('Configured by configurator')
+        _LOGGER.debug('Continuing setup configured by configurator')
     elif all(key in config.get(DOMAIN, {}) for key in legacy_conf_keys):
         # Can we get voiuptous to do this for us?
         # i.e. have a group of configuration items that

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -90,7 +90,7 @@ def setup(hass, config, session):
 
         configurator = hass.components.configurator
         hass.data.setdefault(KEY_CONFIG, {})
-        instance = hass.data[KEY_CONFIG].get(host)
+        instance = hass.data[KEY_CONFIG].get(host or DOMAIN)
 
         # Configuration already in progress
         if instance:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -62,7 +62,7 @@ ATTR_LAST_UPDATED = 'time_last_updated'
 def setup(hass, config, session):
     """Set up the Telldus Live component."""
 
-    from tellduslive import Client, LocalAPISession, LiveSession
+    from tellduslive import LocalAPISession, LiveSession
     
     config_filename = hass.config.path(TELLLDUS_CONFIG_FILE)
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -182,13 +182,13 @@ def setup(hass, config, session=None):
 
     conf = load_config()
 
-    LEGACY_CONF_KEYS = {CONF_PUBLIC_KEY,
+    legacy_conf_keys = {CONF_PUBLIC_KEY,
                         CONF_PRIVATE_KEY,
                         CONF_TOKEN,
                         CONF_TOKEN_SECRET}
     if session:
         _LOGGER.debug('Configured by configurator')
-    elif all(key in config.get(DOMAIN, {}) for key in LEGACY_CONF_KEYS):
+    elif all(key in config.get(DOMAIN, {}) for key in legacy_conf_keys):
         # Can we get voiuptous to do this?
         # i.e. have a group of configuration items that
         # are optional, but if any is present, all have to be.
@@ -199,7 +199,7 @@ def setup(hass, config, session=None):
         session = LiveSession(application=PROJECT_NAME,
                               **{key: val
                                  for key, val in config[DOMAIN].items()
-                                 if key in LEGACY_CONF_KEYS})
+                                 if key in legacy_conf_keys})
     elif CONF_HOST in conf:
         _LOGGER.debug('Using Local API pre-configured by configurator')
         session = LocalAPISession(**conf[CONF_HOST])

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -86,7 +86,7 @@ def setup(hass, config, session):
             _LOGGER.error("Reading config file failed: %s", error)
 
     def request_configuration(host=None):
-        """Request TelldusLive authorized."""
+        """Request TelldusLive authorization."""
 
         configurator = hass.components.configurator
         hass.data.setdefault(KEY_CONFIG, {})
@@ -124,7 +124,7 @@ def setup(hass, config, session):
             def success():
                 """Set up was successful."""
                 # Save config
-                if not load_config(
+                if not save_config(
                         {host or DOMAIN: {
                             CONF_TOKEN: access_token,
                         }}):

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -80,7 +80,7 @@ def setup(hass, config, local=None, oauth=None):
         except (ValueError, IOError) as error:
             _LOGGER.error("Reading config file failed: %s", error)
 
-    def request_configuration(hass, config, host=None):
+    def request_configuration(host=None):
         """Request TelldusLive authorized."""
 
         configurator = hass.components.configurator

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -137,7 +137,7 @@ def setup(hass, config, local=None, oauth=None):
             return  # Tellstick already configured
         host, device = info
         if not any(x in device for x in LOCAL_API_DEVICES):
-            hass.async_add_job(request_configuration, hass, config)
+            hass.async_add_job(request_configuration)
             return
 
         file_config = load_config()
@@ -145,8 +145,8 @@ def setup(hass, config, local=None, oauth=None):
             file_host, _ = file_config.popitem()
             if file_host == host:
                 return
-        hass.async_add_job(request_configuration, hass, config)
-        hass.async_add_job(request_configuration, hass, config, host)
+        hass.async_add_job(request_configuration)
+        hass.async_add_job(request_configuration, host)
 
     discovery.async_listen(hass, SERVICE_TELLDUSLIVE, tellstick_discovered)
 
@@ -177,7 +177,7 @@ def setup(hass, config, local=None, oauth=None):
     if host is None and oauth is None and cnf_live:
         if cnf_live:
             _LOGGER.info("Configure TelldusLive")
-            hass.async_add_job(request_configuration, hass, config)
+            hass.async_add_job(request_configuration)
         return True
 
     client = TelldusLiveClient(hass, config, host, token, oauth)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -128,7 +128,7 @@ def setup(hass, config, client=None):
             def success():
                 """Set up was successful."""
                 conf.update(
-                    {host: {CONF_TOKEN: client.access_token}} if host else
+                    {host: {CONF_HOST: host, CONF_TOKEN: client.access_token}} if host else
                     {DOMAIN: {CONF_TOKEN: client.access_token,
                               CONF_TOKEN_SECRET: client.access_token_secret}})
                 if not save_config(config_filename, conf):
@@ -200,9 +200,10 @@ def setup(hass, config, client=None):
                         **{key: val
                            for key, val in config[DOMAIN].items()
                            if key in legacy_conf_keys})
-    elif CONF_HOST in conf:
+    elif CONF_HOST in next(iter(conf.values())):
+        #  For now, only one local device is supported
         _LOGGER.debug('Using Local API pre-configured by configurator')
-        client = Client(**conf[CONF_HOST])
+        client = Client(**next(iter(conf.values())))
     elif DOMAIN in conf:
         _LOGGER.debug('Using TelldusLive cloud service '
                       'pre-configured by configurator')

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -11,7 +11,8 @@ import logging
 
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, DEVICE_DEFAULT_NAME,
-    PROJECT_NAME, CONF_TOKEN, CONF_HOST)
+    PROJECT_NAME, CONF_TOKEN, CONF_HOST,
+    EVENT_HOMEASSISTANT_START)
 from homeassistant.helpers import discovery
 from homeassistant.components.discovery import SERVICE_TELLDUSLIVE
 import homeassistant.helpers.config_validation as cv
@@ -65,6 +66,7 @@ def save_config(filename, config=None):
         _LOGGER.error("Saving config file %s failed: %s",
                       filename, error)
 
+
 def load_config(filename):
     """Load configurator configuration."""
     try:
@@ -77,6 +79,7 @@ def load_config(filename):
         _LOGGER.warning('Reading config file %s failed: %s',
                         filename, error)
     return {}
+
 
 def setup(hass, config, client=None):
     """Set up the Telldus Live component."""
@@ -124,9 +127,10 @@ def setup(hass, config, client=None):
             @asyncio.coroutine
             def success():
                 """Set up was successful."""
-                conf.update({host: {CONF_TOKEN: client.access_token}} if host else
-                            {DOMAIN: {CONF_TOKEN: client.access_token,
-                                      CONF_TOKEN_SECRET: client.access_token_secret}})
+                conf.update(
+                    {host: {CONF_TOKEN: client.access_token}} if host else
+                    {DOMAIN: {CONF_TOKEN: client.access_token,
+                              CONF_TOKEN_SECRET: client.access_token_secret}})
                 if not save_config(config_filename, conf):
                     _LOGGER.warning('Failed to save configuration file %s',
                                     config_filename)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -22,7 +22,7 @@ import voluptuous as vol
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.7.0']
+REQUIREMENTS = ['tellduslive==0.7.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,8 +36,6 @@ CONF_UPDATE_INTERVAL = 'update_interval'
 
 PUBLIC_KEY = 'THUPUNECH5YEQA3RE6UYUPRUZ2DUGUGA'
 NOT_SO_PRIVATE_KEY = 'PHES7U2RADREWAFEBUSTUBAWRASWUTUS'
-
-SUPPORTS_LOCAL_API = ['TellstickZnet', 'TellstickNetV2']
 
 MIN_UPDATE_INTERVAL = timedelta(seconds=5)
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
@@ -59,7 +57,7 @@ ATTR_LAST_UPDATED = 'time_last_updated'
 
 def setup(hass, config, client=None):
     """Set up the Telldus Live component."""
-    from tellduslive import Client
+    from tellduslive import Client, supports_local_api
     config_filename = hass.config.path(TELLLDUS_CONFIG_FILE)
 
     def save_config(config=None):
@@ -159,9 +157,7 @@ def setup(hass, config, client=None):
 
         host, device = info
 
-        supports_local_api = any(dev in device
-                                 for dev in SUPPORTS_LOCAL_API)
-        if not supports_local_api:
+        if not supports_local_api(device):
             # Configure the cloud service
             hass.async_add_job(request_configuration)
             return

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -82,7 +82,6 @@ def config_from_file(filename, config=None):
 
 def request_configuration(hass, config, host=None):
     """Request TelldusLive authorized."""
-    logger = logging.getLogger(__name__)
 
     configurator = hass.components.configurator
     hass.data.setdefault(KEY_CONFIG, {})
@@ -92,7 +91,7 @@ def request_configuration(hass, config, host=None):
     if instance:
         return
 
-    logger.info("Found TelldusLive local client: %s" % host)
+    _LOGGER.info("Found TelldusLive local client: %s" % host)
     from tellduslive import Client
     auth_url, request_token = Client.get_authorize_url(host, app='HA')
     if not auth_url:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -208,9 +208,13 @@ def setup(hass, config, client=None):
                       'pre-configured by configurator')
         client = Client(PUBLIC_KEY, NOT_SO_PRIVATE_KEY,
                         application=PROJECT_NAME, **conf[DOMAIN])
-    else:
-        _LOGGER.info('Requesting TelldusLive cloud service configuration')
+    elif config.get(DOMAIN):
+        _LOGGER.info('Found entry in configuration.yaml. '
+                     'Requesting TelldusLive cloud service configuration')
         hass.async_add_job(request_configuration)
+        return True
+    else:
+        _LOGGER.info('Tellstick discovered, awaiting discovery callback')
         return True
 
     session = TelldusLiveSession(hass, config, client)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -91,7 +91,8 @@ def setup(hass, config, local=None, oauth=None):
         if instance:
             return
 
-        _LOGGER.info('Configuring TelldusLive local client: {}'.format(host))
+        _LOGGER.info('Configuring TelldusLive local client: {}'.format(host) if host else
+                     'Configuring TelldusLive cloud service')
         from tellduslive import Client
         auth_url, request_token = Client.get_authorize_url(host, app='HA')
         if not auth_url:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -22,7 +22,7 @@ import voluptuous as vol
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.5.0']
+REQUIREMENTS = ['tellduslive==0.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ def setup(hass, config, session=None):
         if host:
             session = LocalAPISession(host=host, app=PROJECT_NAME)
         else:
-            session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY)
+            session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY, app=PROJECT_NAME)
 
         auth_url = session.get_authorize_url()
         if not auth_url:
@@ -188,7 +188,7 @@ def setup(hass, config, session=None):
                         'Please consider removing developer keys '
                         'from configuration and instead'
                         'authenticate via user interface.')
-        session = LiveSession(**config[DOMAIN])
+        session = LiveSession(**config[DOMAIN], app=PROJECT_NAME)
     elif CONF_HOST in conf:
         # Local API already configured
         _LOGGER.debug('Using already configured Local API')
@@ -196,7 +196,7 @@ def setup(hass, config, session=None):
     elif DOMAIN in conf:
         # Cloud API already configured
         _LOGGER.debug('Using already configured cloud live API')
-        session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY, **conf[DOMAIN])
+        session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY, app=PROJECT_NAME, **conf[DOMAIN])
     else:
         # Empty tellduslive entry, configure it as cloud service
         _LOGGER.info('Needs TelldusLive cloud service configuration')

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -251,8 +251,7 @@ class TelldusLiveSession(object):
 
     def validate(self):
         """Make a request to see if the session is valid."""
-        response = self._client.request_user()
-        return response and 'email' in response
+        return self._client.update()
 
     def update(self, *args):
         """Periodically poll the servers for current state."""

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -80,7 +80,7 @@ def config_from_file(filename, config=None):
             return {}
 
 
-def request_local_configuration(hass, config, host):
+def request_configuration(hass, config, host=None):
     """Request TelldusLive authorized."""
     logger = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ def setup(hass, config, local=None, oauth=None):
             return  # Tellstick already configured
         host, device = info[0], info[1]
         if not any(x in device for x in LOCAL_API_DEVICES):
-            hass.async_add_job(request_live_configuration, hass, config, host)
+            hass.async_add_job(request_configuration, hass, config)
             return
 
         file_config = config_from_file(hass.config.path(TELLLDUS_CONFIG_FILE))
@@ -150,8 +150,8 @@ def setup(hass, config, local=None, oauth=None):
             file_host, _ = file_config.popitem()
             if file_host == host:
                 return
-        hass.async_add_job(request_live_configuration, hass, config, host)
-        hass.async_add_job(request_local_configuration, hass, config, host)
+        hass.async_add_job(request_configuration, hass, config)
+        hass.async_add_job(request_configuration, hass, config, host)
 
     discovery.async_listen(hass, SERVICE_TELLDUSLIVE, tellstick_discovered)
 
@@ -182,7 +182,7 @@ def setup(hass, config, local=None, oauth=None):
     if host is None and oauth is None and cnf_live:
         if cnf_live:
             _LOGGER.info("Configure TelldusLive")
-            hass.async_add_job(request_live_configuration, hass, config, DOMAIN)
+            hass.async_add_job(request_configuration, hass, config)
         return True
 
     client = TelldusLiveClient(hass, config, host, token, oauth)

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -147,11 +147,15 @@ def setup(hass, config, session):
         """Run when a Tellstick is discovered."""
         if DOMAIN in hass.data:
             return  # Already configured
+
         host, device = info
+
         if not any(x in device for x in LOCAL_API_DEVICES):
+            # Configure the cloud service
             hass.async_add_job(request_configuration)
             return
 
+        # Configure local API access with optional cloud service
         file_config = load_config()
         if file_config:
             file_host, _ = file_config.popitem()

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -250,8 +250,8 @@ class TelldusLiveSession(object):
         self._client = client
 
     def validate(self):
-        """Make a request to see if the session is valid."""
-        return self._client.update()
+        """Check to see if the session is valid."""
+        return self._client.is_authorized
 
     def update(self, *args):
         """Periodically poll the servers for current state."""

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -155,15 +155,21 @@ def setup(hass, config, client=None):
 
     def tellstick_discovered(service, info):
         """Run when a Tellstick is discovered."""
+        _LOGGER.info('Discovered tellstick device')
+
         if DOMAIN in hass.data:
-            return  # Already configured
+            _LOGGER.debug('Tellstick already configured')
+            return
 
         host, device = info
 
         if not supports_local_api(device):
+            _LOGGER.debug('Tellstick does not support local API')
             # Configure the cloud service
             hass.async_add_job(request_configuration)
             return
+
+        _LOGGER.debug('Tellstick does support local API')
 
         # Ignore any known devices
         if conf and host in conf:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -118,23 +118,19 @@ def setup(hass, config, local=None, oauth=None):
         try:
             with open(config_filename, 'w') as fdesc:
                 fdesc.write(json.dumps(config))
+            return True
         except IOError as error:
             _LOGGER.error("Saving config file failed: %s", error)
-            return False
-        return True
-
+ 
     def load_config():
         """Load configuration:"""
-        if os.path.isfile(config_filename):
-            try:
-                with open(config_filename, 'r') as fdesc:
-                    return json.loads(fdesc.read())
-            except (ValueError, IOError) as error:
-                _LOGGER.error("Reading config file failed: %s", error)
-                # This won't work yet
-                return False
-        else:
+        if not os.path.isfile(config_filename):
             return {}
+        try:
+            with open(config_filename, 'r') as fdesc:
+                return json.loads(fdesc.read())
+        except (ValueError, IOError) as error:
+            _LOGGER.error("Reading config file failed: %s", error)
 
     def tellstick_discovered(service, info):
         """Run when a Tellstick is discovered."""

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -116,8 +116,8 @@ def setup(hass, config, local=None, oauth=None):
     def save_config(config=None):
         """Save configuration."""
         try:
-            with open(config_filename, 'w') as fdesc:
-                fdesc.write(json.dumps(config))
+            with open(config_filename, 'w') as f:
+                f.write(json.dumps(config))
             return True
         except IOError as error:
             _LOGGER.error("Saving config file failed: %s", error)
@@ -127,8 +127,8 @@ def setup(hass, config, local=None, oauth=None):
         if not os.path.isfile(config_filename):
             return {}
         try:
-            with open(config_filename, 'r') as fdesc:
-                return json.loads(fdesc.read())
+            with open(config_filename) as f:
+                return json.loads(f.read())
         except (ValueError, IOError) as error:
             _LOGGER.error("Reading config file failed: %s", error)
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -36,6 +36,9 @@ CONF_TOKEN_SECRET = 'token_secret'
 CONF_HOST = 'host'
 CONF_UPDATE_INTERVAL = 'update_interval'
 
+PUBLIC_KEY='THUPUNECH5YEQA3RE6UYUPRUZ2DUGUGA'
+NOT_SO_PRIVATE_KEY='PHES7U2RADREWAFEBUSTUBAWRASWUTUS'
+
 LOCAL_API_DEVICES = ['TellstickZnet', 'TellstickNetV2']
 
 MIN_UPDATE_INTERVAL = timedelta(seconds=5)
@@ -95,8 +98,13 @@ def setup(hass, config, local=None, oauth=None):
             'local client: {}'.format(host) if host else
             'cloud service'))
 
-        from tellduslive import Client
-        auth_url, request_token = Client.get_authorize_url(host, app=PROJECT_NAME)
+        from tellduslive import LocalAPISession, LiveSession
+        if host:
+            session = LocalAPISession(host=host, app=PROJECT_NAME)
+        else:
+            session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY)
+
+        auth_url = session.get_authorize_url()
         if not auth_url:
             return
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -56,8 +56,9 @@ CONFIG_SCHEMA = vol.Schema({
 ATTR_LAST_UPDATED = 'time_last_updated'
 
 
-def config_from_file(filename, config=None):
+def config_from_file(hass, config=None):
     """Small configuration file management function (from media_player/plex.py)."""
+    filename = hass.config.path(TELLLDUS_CONFIG_FILE)
     if config:
         # We're writing configuration
         try:
@@ -113,7 +114,7 @@ def request_configuration(hass, config, host=None):
             """Set up was successful."""
             # Save config
             if not config_from_file(
-                    hass.config.path(TELLLDUS_CONFIG_FILE), {host: {
+                    hass, {host: {
                         CONF_TOKEN: access_token,
                     }}):
                 _LOGGER.error("Failed to save configuration file")
@@ -145,7 +146,7 @@ def setup(hass, config, local=None, oauth=None):
             hass.async_add_job(request_configuration, hass, config)
             return
 
-        file_config = config_from_file(hass.config.path(TELLLDUS_CONFIG_FILE))
+        file_config = config_from_file(hass)
         if file_config:
             file_host, _ = file_config.popitem()
             if file_host == host:
@@ -158,7 +159,7 @@ def setup(hass, config, local=None, oauth=None):
     host = None
     token = None
     # get config from tellduslive.conf
-    file_config = config_from_file(hass.config.path(TELLLDUS_CONFIG_FILE))
+    file_config = config_from_file(hass)
     # Via discovery
     if local is not None:
         # Parse discovery data

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -111,7 +111,7 @@ def request_configuration(hass, config, host=None):
 def setup(hass, config, local=None, oauth=None):
     """Set up the Telldus Live component."""
 
-    def config_from_file(hass, config=None):
+    def config_from_file(config=None):
         """Small configuration file management function (from media_player/plex.py)."""
         filename = hass.config.path(TELLLDUS_CONFIG_FILE)
         if config:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -87,8 +87,8 @@ def request_configuration(hass, config, host=None):
         def success():
             """Set up was successful."""
             # Save config
-            if not config_from_file(
-                    hass, {host: {
+            if not load_config(
+                    {host: {
                         CONF_TOKEN: access_token,
                     }}):
                 _LOGGER.error("Failed to save configuration file")
@@ -141,7 +141,7 @@ def setup(hass, config, local=None, oauth=None):
             hass.async_add_job(request_configuration, hass, config)
             return
 
-        file_config = config_from_file(hass)
+        file_config = load_config()
         if file_config:
             file_host, _ = file_config.popitem()
             if file_host == host:
@@ -154,7 +154,7 @@ def setup(hass, config, local=None, oauth=None):
     host = None
     token = None
     # get config from tellduslive.conf
-    file_config = config_from_file(hass)
+    file_config = load_config()
     # Via discovery
     if local is not None:
         # Parse discovery data

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -62,6 +62,8 @@ ATTR_LAST_UPDATED = 'time_last_updated'
 def setup(hass, config, session):
     """Set up the Telldus Live component."""
 
+    from tellduslive import Client, LocalAPISession, LiveSession
+    
     config_filename = hass.config.path(TELLLDUS_CONFIG_FILE)
 
     def save_config(config=None):
@@ -98,7 +100,6 @@ def setup(hass, config, session):
             'local client: {}'.format(host) if host else
             'cloud service'))
 
-        from tellduslive import LocalAPISession, LiveSession
         if host:
             session = LocalAPISession(host=host, app=PROJECT_NAME)
         else:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -124,7 +124,7 @@ def setup(hass, config, local=None, oauth=None):
             hass.async_add_job(success)
 
         hass.data[KEY_CONFIG][host] = configurator.request_config(
-            "TelldusLive - LocalAPI",
+            'TelldusLive ({})'.format('LocalAPI' if host else 'Cloud service'),
             configuration_callback,
             description=('To link your TelldusLive account ',
                         'click the link, login, and authorize:'),

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -85,7 +85,6 @@ def setup(hass, config, client=None):
 
     def request_configuration(host=None):
         """Request TelldusLive authorization."""
-        from tellduslive import Client
         configurator = hass.components.configurator
         hass.data.setdefault(KEY_CONFIG, {})
         data_key = host or DOMAIN
@@ -226,8 +225,6 @@ class TelldusLiveClient(object):
 
     def __init__(self, hass, config, client):
         """Initialize the Tellus data object."""
-        from tellduslive import Client
-
         self.entities = []
 
         self._hass = hass

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -22,7 +22,7 @@ import voluptuous as vol
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.4.0']
+REQUIREMENTS = ['tellduslive==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -91,7 +91,7 @@ def setup(hass, config, local=None, oauth=None):
         if instance:
             return
 
-        _LOGGER.info("Configuring TelldusLive local client: %s" % host)
+        _LOGGER.info('Configuring TelldusLive local client: {}'.format(host))
         from tellduslive import Client
         auth_url, request_token = Client.get_authorize_url(host, app='HA')
         if not auth_url:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -108,10 +108,11 @@ def setup(hass, config, local=None, oauth=None):
         if not auth_url:
             return
 
+        _LOGGER.debug('Got authorization URL %s', auth_url)
+
         def configuration_callback(callback_data):
             """Handle the submitted configuration."""
-            from tellduslive import Client
-            access_token = Client.authorize_local_api(host, request_token)
+            session.authorize()
             res = setup(hass, config, local={CONF_HOST: host, CONF_TOKEN: access_token})
             if not res:
                 hass.async_add_job(configurator.notify_errors, instance,
@@ -123,7 +124,7 @@ def setup(hass, config, local=None, oauth=None):
                 """Set up was successful."""
                 # Save config
                 if not load_config(
-                        {host: {
+                        {host or DOMAIN: {
                             CONF_TOKEN: access_token,
                         }}):
                     _LOGGER.error("Failed to save configuration file")
@@ -134,9 +135,9 @@ def setup(hass, config, local=None, oauth=None):
         hass.data[KEY_CONFIG][host] = configurator.request_config(
             'TelldusLive ({})'.format('LocalAPI' if host else 'Cloud service'),
             configuration_callback,
-            description=('To link your TelldusLive account ',
-                        'click the link, login, and authorize:'),
-            submit_caption='I authorized successfully',
+            description=('To link your TelldusLive account, '
+                         'click the link, login, and authorize {}. Then click Confirm button.'.format(PROJECT_NAME)),
+            submit_caption='Confirm',
             link_name="Link TelldusLive account",
             link_url=auth_url,
             entity_picture='/static/images/logo_tellduslive.png',

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -94,6 +94,7 @@ def setup(hass, config, local=None, oauth=None):
         _LOGGER.info('Configuring TelldusLive {}'.format(
             'local client: {}'.format(host) if host else
             'cloud service'))
+
         from tellduslive import Client
         auth_url, request_token = Client.get_authorize_url(host, app='HA')
         if not auth_url:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -91,8 +91,9 @@ def setup(hass, config, local=None, oauth=None):
         if instance:
             return
 
-        _LOGGER.info('Configuring TelldusLive local client: {}'.format(host) if host else
-                     'Configuring TelldusLive cloud service')
+        _LOGGER.info('Configuring TelldusLive {}'.format(
+            'local client: {}'.format(host) if host else
+            'cloud service'))
         from tellduslive import Client
         auth_url, request_token = Client.get_authorize_url(host, app='HA')
         if not auth_url:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -56,32 +56,6 @@ CONFIG_SCHEMA = vol.Schema({
 ATTR_LAST_UPDATED = 'time_last_updated'
 
 
-def config_from_file(hass, config=None):
-    """Small configuration file management function (from media_player/plex.py)."""
-    filename = hass.config.path(TELLLDUS_CONFIG_FILE)
-    if config:
-        # We're writing configuration
-        try:
-            with open(filename, 'w') as fdesc:
-                fdesc.write(json.dumps(config))
-        except IOError as error:
-            _LOGGER.error("Saving config file failed: %s", error)
-            return False
-        return True
-    else:
-        # We're reading config
-        if os.path.isfile(filename):
-            try:
-                with open(filename, 'r') as fdesc:
-                    return json.loads(fdesc.read())
-            except (ValueError, IOError) as error:
-                _LOGGER.error("Reading config file failed: %s", error)
-                # This won't work yet
-                return False
-        else:
-            return {}
-
-
 def request_configuration(hass, config, host=None):
     """Request TelldusLive authorized."""
 
@@ -136,6 +110,31 @@ def request_configuration(hass, config, host=None):
 
 def setup(hass, config, local=None, oauth=None):
     """Set up the Telldus Live component."""
+
+    def config_from_file(hass, config=None):
+        """Small configuration file management function (from media_player/plex.py)."""
+        filename = hass.config.path(TELLLDUS_CONFIG_FILE)
+        if config:
+            # We're writing configuration
+            try:
+                with open(filename, 'w') as fdesc:
+                    fdesc.write(json.dumps(config))
+            except IOError as error:
+                _LOGGER.error("Saving config file failed: %s", error)
+                return False
+            return True
+        else:
+            # We're reading config
+            if os.path.isfile(filename):
+                try:
+                    with open(filename, 'r') as fdesc:
+                        return json.loads(fdesc.read())
+                except (ValueError, IOError) as error:
+                    _LOGGER.error("Reading config file failed: %s", error)
+                    # This won't work yet
+                    return False
+            else:
+                return {}
 
     def tellstick_discovered(service, info):
         """Run when a Tellstick is discovered."""

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -22,7 +22,7 @@ import voluptuous as vol
 
 DOMAIN = 'tellduslive'
 
-REQUIREMENTS = ['tellduslive==0.6.0']
+REQUIREMENTS = ['tellduslive==0.6.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,9 +100,9 @@ def setup(hass, config, session=None):
             'cloud service'))
 
         if host:
-            session = LocalAPISession(host=host, app=PROJECT_NAME)
+            session = LocalAPISession(host=host, application=PROJECT_NAME)
         else:
-            session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY, app=PROJECT_NAME)
+            session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY, application=PROJECT_NAME)
 
         auth_url = session.get_authorize_url()
         if not auth_url:
@@ -188,7 +188,7 @@ def setup(hass, config, session=None):
                         'Please consider removing developer keys '
                         'from configuration and instead'
                         'authenticate via user interface.')
-        session = LiveSession(**config[DOMAIN], app=PROJECT_NAME)
+        session = LiveSession(application=PROJECT_NAME, **config[DOMAIN])
     elif CONF_HOST in conf:
         # Local API already configured
         _LOGGER.debug('Using already configured Local API')
@@ -196,7 +196,7 @@ def setup(hass, config, session=None):
     elif DOMAIN in conf:
         # Cloud API already configured
         _LOGGER.debug('Using already configured cloud live API')
-        session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY, app=PROJECT_NAME, **conf[DOMAIN])
+        session = LiveSession(PUBLIC_KEY, NOT_SO_PRIVATE_KEY, application=PROJECT_NAME, **conf[DOMAIN])
     else:
         # Empty tellduslive entry, configure it as cloud service
         _LOGGER.info('Needs TelldusLive cloud service configuration')

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -127,7 +127,8 @@ def setup(hass, config, client=None):
             def success():
                 """Set up was successful."""
                 conf.update(
-                    {host: {CONF_HOST: host, CONF_TOKEN: client.access_token}} if host else
+                    {host: {CONF_HOST: host,
+                            CONF_TOKEN: client.access_token}} if host else
                     {DOMAIN: {CONF_TOKEN: client.access_token,
                               CONF_TOKEN_SECRET: client.access_token_secret}})
                 if not save_config(config_filename, conf):

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -91,7 +91,7 @@ def setup(hass, config, local=None, oauth=None):
         if instance:
             return
 
-        _LOGGER.info("Found TelldusLive local client: %s" % host)
+        _LOGGER.info("Configuring TelldusLive local client: %s" % host)
         from tellduslive import Client
         auth_url, request_token = Client.get_authorize_url(host, app='HA')
         if not auth_url:

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -113,29 +113,28 @@ def setup(hass, config, local=None, oauth=None):
 
     config_filename = hass.config.path(TELLLDUS_CONFIG_FILE)
 
-    def config_from_file(config=None):
-        """Small configuration file management function (from media_player/plex.py)."""
-        if config:
-            # We're writing configuration
+    def save_config(config=None):
+        """Save configuration."""
+        try:
+            with open(config_filename, 'w') as fdesc:
+                fdesc.write(json.dumps(config))
+        except IOError as error:
+            _LOGGER.error("Saving config file failed: %s", error)
+            return False
+        return True
+
+    def load_config():
+        """Load configuration:"""
+        if os.path.isfile(config_filename):
             try:
-                with open(config_filename, 'w') as fdesc:
-                    fdesc.write(json.dumps(config))
-            except IOError as error:
-                _LOGGER.error("Saving config file failed: %s", error)
+                with open(config_filename, 'r') as fdesc:
+                    return json.loads(fdesc.read())
+            except (ValueError, IOError) as error:
+                _LOGGER.error("Reading config file failed: %s", error)
+                # This won't work yet
                 return False
-            return True
         else:
-            # We're reading config
-            if os.path.isfile(config_filename):
-                try:
-                    with open(config_filename, 'r') as fdesc:
-                        return json.loads(fdesc.read())
-                except (ValueError, IOError) as error:
-                    _LOGGER.error("Reading config file failed: %s", error)
-                    # This won't work yet
-                    return False
-            else:
-                return {}
+            return {}
 
     def tellstick_discovered(service, info):
         """Run when a Tellstick is discovered."""

--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -187,7 +187,7 @@ def setup(hass, config, client=None):
         # are optional, but if any is present, all have to be.
         _LOGGER.warning('Old configuration format detected. '
                         'Please consider removing developer keys '
-                        'from configuration and instead'
+                        'from configuration and instead '
                         'authenticate via user interface.')
         client = Client(application=PROJECT_NAME,
                         **{key: val

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -997,7 +997,7 @@ tapsaff==0.1.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.7.0
+tellduslive==0.7.1
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -997,7 +997,7 @@ tapsaff==0.1.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.4.0
+tellduslive==0.5.0
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -997,7 +997,7 @@ tapsaff==0.1.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.6.0
+tellduslive==0.6.1
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -997,7 +997,7 @@ tapsaff==0.1.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.5.0
+tellduslive==0.6.0
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -997,7 +997,7 @@ tapsaff==0.1.3
 tellcore-py==1.1.2
 
 # homeassistant.components.tellduslive
-tellduslive==0.6.1
+tellduslive==0.7.0
 
 # homeassistant.components.sensor.temper
 temperusb==1.5.3


### PR DESCRIPTION
Implementerat stöd för Tellduslive-inloggning via konfigurator, samt unifierat konfigurator-grejen för både localApI och cloud. Har också flyttat en del kod till tellduslive-libbet.

Jag har testat följande fall:
- enbart `tellduslive`: i `configuration.yaml` -> konfiguratorn dyker upp
- omstart med enbart `tellduslive`: i `configuration.yaml` och redan pre-konfigurerat -> läser auth-data från `tellduslive.conf` och loggar in automatiskt.
- "legacy-mode" med developer-keys i `configuration.yaml` (bakåtkompatibelt läge) -> loggar in som vanligt.

Att testa:
- Discovery-mekanismen, för znet ska konfigurering av både cloud och local dyka upp
- znet och enbart `tellduslive`: i `configuration.yaml` -> konfiguratorn dyker upp och ska erbjuda konfigurering av cloud.
- efter omstart med redan konfigurerad znet localapi eller cloud ska auth läsas in från telduslive.conf och fungera

Att göra:
- Token renewal

(Tror du kan göra en "squash and merge" för att slå ihop alla commits i denna PR innan merge)